### PR TITLE
drop ES6 default options assignment

### DIFF
--- a/lib/tar-to-zip.js
+++ b/lib/tar-to-zip.js
@@ -19,8 +19,8 @@ const defaultMap = () => {};
 
 inherits(TarToZip, EventEmitter);
 
-module.exports = (file, options = {}) => {
-    check(file, options);
+module.exports = (file, options) => {
+    this.options = options || {};
     
     const isProgress = options.progress;
     const emitter = new TarToZip(file, options);


### PR DESCRIPTION
This restored compatibility with Ubuntu 17.04's nodejs 4.7.2 for me.